### PR TITLE
Add docker image to publishing workflow

### DIFF
--- a/.github/workflows/stage-publish.yaml
+++ b/.github/workflows/stage-publish.yaml
@@ -37,6 +37,11 @@ jobs:
       - name: Set BUILD_GIT_HASH
         run: |
           echo "BUILD_GIT_HASH=$(cd ./pulumi-service && git rev-parse HEAD)" >> $GITHUB_ENV
+      - name: Login to Docker Hub as pulumi-bot
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_PASSWORD }}
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v5
         with:

--- a/.goreleaser.prerelease.yaml
+++ b/.goreleaser.prerelease.yaml
@@ -70,6 +70,13 @@ archives:
         format: zip
     wrap_in_directory: customer-managed-deployment-agent
 
+dockers:
+  - image_templates:
+    - pulumi/customer-managed-deployment-agent:{{ .TAG }}
+    build_flag_templates:
+      - --build-arg=AGENTBINARY={{ .Builds.customer-managed-deployment-agent.binary }}
+      - --build-arg=RUNNERBINARY={{ .Builds.workflow-runner.binary }}
+
 signs:
   - cmd: cosign
     stdin: '{{ .Env.COSIGN_PASSWORD }}'

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -66,6 +66,14 @@ archives:
         format: zip
     wrap_in_directory: customer-managed-deployment-agent
 
+dockers:
+  - image_templates:
+      - pulumi/customer-managed-deployment-agent:{{ .TAG }}
+      - pulumi/customer-managed-deployment-agent:latest
+    build_flag_templates:
+      - --build-arg=AGENTBINARY={{ .Builds.customer-managed-deployment-agent.binary }}
+      - --build-arg=RUNNERBINARY={{ .Builds.workflow-runner.binary }}
+
 signs:
   - cmd: cosign
     stdin: '{{ .Env.COSIGN_PASSWORD }}'

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM alpine:3.18
+
+ENV PATH="${PATH}:/usr/local/bin"
+
+ARG AGENTBINARY
+ARG RUNNERBINARY
+
+COPY ${AGENTBINARY} /usr/local/bin/customer-managed-deployment-agent
+COPY ${RUNNERBINARY} /usr/local/bin/workflow-runner
+
+RUN chmod +x /usr/local/bin/customer-managed-deployment-agent /usr/local/bin/workflow-runner
+
+CMD [ "customer-managed-deployment-agent", "run"]


### PR DESCRIPTION
- Add root Dockerfile that will be called from goreleaser
- Update goreleaser configurations to include docker publish
- Update the GHA publish workflow to login to the docker registry

Fix https://github.com/pulumi/pulumi-service/issues/20772