### PR TITLE
Adding in the ability to append to envVars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 CHANGELOG
 =========
 
+1.3.5(Unreleased)
+
+* Added envVars to the codebase so that users don't have to modify the component.
+
 1.3.4 (2024-10-29)
 
 * Added environment variable: PULUMI_AGENT_DEBUG_POD to allow users to keep pod behind for troubleshooting and inspection

--- a/kubernetes/agent.ts
+++ b/kubernetes/agent.ts
@@ -9,6 +9,7 @@ export interface PulumiSelfHostedAgentComponentArgs {
     selfHostedAgentsAccessToken: pulumi.Input<string>;
     selfHostedServiceURL: pulumi.Input<string>;
     workerServiceAccount?: kubernetes.core.v1.ServiceAccount;
+    envVars?: kubernetes.types.input.core.v1.EnvVar[]
 }
 
 export class PulumiSelfHostedAgentComponent extends pulumi.ComponentResource {
@@ -165,7 +166,7 @@ export class PulumiSelfHostedAgentComponent extends pulumi.ComponentResource {
                                         },
                                     },
                                     workerServiceAccountEnvVar,
-
+                                    ...(args.envVars || [])
                                 ],
                                 volumeMounts: [
                                     {


### PR DESCRIPTION
This will allow users to add envars from their script, like: PULUMI_AGENT_DEBUG_POD, without having to modify the component, so that they can submodule and keep up to date, and then use the component like this: 
```
import { PulumiSelfHostedAgentComponent } from "./customer-managed-deployment-agent/kubernetes/agent"
const env = [
    {
        name: "PULUMI_AGENT_DEBUG_POD",
        value: "true"
    }
]

const agent = new PulumiSelfHostedAgentComponent(
    "self-hosted-agent",
    {
        namespace: ns,
        imageName: pulumiConfig.require("agentImage"),
        selfHostedAgentsAccessToken: pulumiConfig.requireSecret("selfHostedAgentsAccessToken"),
        selfHostedServiceURL: pulumiConfig.get("selfHostedServiceURL") ?? "https://api.pulumi.com",
        imagePullPolicy: pulumiConfig.get("agentImagePullPolicy") || "Always",
        agentReplicas: pulumiConfig.getNumber("agentReplicas") || 3,
        env
    },
    { provider: k8sProvider, dependsOn: [ns] },
)
```