### PR TITLE
Update pulumi-service

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,15 +1,19 @@
 CHANGELOG
 =========
 
-1.3.8(2025-02-19)
+1.4.0 (2025-06-23)
 
-* fixing issue with node selection where it might get multiple nodes [https://github.com/pulumi/pulumi-service/pull/24650]
+* Added `healthz` endpoint to the agent for health checks
 
-1.3.7(2024-12-03)
+1.3.8 (2025-02-19)
+
+* Fixes an issue with node selection where it might get multiple nodes
+
+1.3.7 (2024-12-03)
 
 * Added support for requests via: `PULUMI_AGENT_NUM_CPUS`, and `PULUMI_AGENT_MEM_QUANTITY`
 
-1.3.6(2024-11-14)
+1.3.6 (2024-11-14)
 
 * Added `--debug` flag to pulumi-deploy-executor pulumi update command to allow for pulumi update to send debug logs
 * Added envVars to the codebase so that users don't have to modify the component.


### PR DESCRIPTION
This change adds an HTTP endpoint for retrieving the agent's health status. This can be used for liveness probes.

In detail, this checks whether the agent loop is making progress and isn't stuck. Job polling and execution send regular heartbeats. The health status will be reported as unhealthy if no heartbeat was received within the expected timeframe. By default this is double the `polling_interval` or `job_status_loop_interval`, whichever number is greater. I've picked `2x` of those intervals to ensure we're not flip-flop in case the status checks happen at exactly the same cadence. Users can also overwrite this with the `health_threshold` config option.

The healthz response looks like this and returns either 200/503 depending on the health state:
```json
{
  "status": "healthy",
  "currentTime": "2025-06-22T21:15:38.338784381Z",
  "lastActivity": "2025-06-22T21:15:11.931901718Z"
}
```