### PR TITLE
Override `REPO_OWNER` for local testing.

### DIFF
--- a/.github/workflows/stage-publish.yaml
+++ b/.github/workflows/stage-publish.yaml
@@ -54,3 +54,5 @@ jobs:
         with:
           args: ${{ inputs.goreleaser-args }}
           version: '~> v2'
+        env:
+          REPO_OWNER: pulumi

--- a/.goreleaser.prerelease.yaml
+++ b/.goreleaser.prerelease.yaml
@@ -63,7 +63,7 @@ builds:
 
 archives:
   - id: customer-managed-deployment-agent
-    builds:
+    ids:
       - customer-managed-deployment-agent
       - workflow-runner
     files:
@@ -77,22 +77,36 @@ archives:
       {{- else }}{{ .Arch }}{{ end }}
     format_overrides:
       - goos: windows
-        format: zip
+        formats: [ "zip" ]
     wrap_in_directory: customer-managed-deployment-agent
 
 dockers:
   - image_templates:
-      - "pulumi/customer-managed-deployment-agent:{{ .Tag }}-amd64"
+      - "{{ .Env.REPO_OWNER }}/customer-managed-deployment-agent:{{ .Tag }}-amd64"
     use: buildx
     goarch: amd64
     build_flag_templates:
       - "--platform=linux/amd64"
+      - "--label=org.opencontainers.image.created={{.Date}}"
+      - "--label=org.opencontainers.image.title={{.ProjectName}}"
+      - "--label=org.opencontainers.image.revision={{.FullCommit}}"
+      - "--label=org.opencontainers.image.version={{.Version}}"
   - image_templates:
-      - "pulumi/customer-managed-deployment-agent:{{ .Tag }}-arm64"
+      - "{{ .Env.REPO_OWNER }}/customer-managed-deployment-agent:{{ .Tag }}-arm64"
     use: buildx
     goarch: arm64
     build_flag_templates:
       - "--platform=linux/arm64"
+      - "--label=org.opencontainers.image.created={{.Date}}"
+      - "--label=org.opencontainers.image.title={{.ProjectName}}"
+      - "--label=org.opencontainers.image.revision={{.FullCommit}}"
+      - "--label=org.opencontainers.image.version={{.Version}}"
+
+docker_manifests:
+  - name_template: "{{ .Env.REPO_OWNER }}/customer-managed-deployment-agent:{{ .Tag }}"
+    image_templates:
+      - "{{ .Env.REPO_OWNER }}/customer-managed-deployment-agent:{{ .Tag }}-amd64"
+      - "{{ .Env.REPO_OWNER }}/customer-managed-deployment-agent:{{ .Tag }}-arm64"
 
 signs:
   - cmd: cosign

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -59,7 +59,7 @@ builds:
 
 archives:
   - id: customer-managed-deployment-agent
-    builds:
+    ids:
       - customer-managed-deployment-agent
       - workflow-runner
     files:
@@ -73,24 +73,42 @@ archives:
       {{- else }}{{ .Arch }}{{ end }}
     format_overrides:
       - goos: windows
-        format: zip
+        formats: [ "zip" ]
     wrap_in_directory: customer-managed-deployment-agent
 
 dockers:
   - image_templates:
-      - "pulumi/customer-managed-deployment-agent:{{ .Tag }}-amd64"
-      - "pulumi/customer-managed-deployment-agent:latest-amd64"
+      - "{{ .Env.REPO_OWNER }}/customer-managed-deployment-agent:{{ .Tag }}-amd64"
+      - "{{ .Env.REPO_OWNER }}/customer-managed-deployment-agent:latest-amd64"
     use: buildx
     goarch: amd64
     build_flag_templates:
       - "--platform=linux/amd64"
+      - "--label=org.opencontainers.image.created={{.Date}}"
+      - "--label=org.opencontainers.image.title={{.ProjectName}}"
+      - "--label=org.opencontainers.image.revision={{.FullCommit}}"
+      - "--label=org.opencontainers.image.version={{.Version}}"
   - image_templates:
-      - "pulumi/customer-managed-deployment-agent:{{ .Tag }}-arm64"
-      - "pulumi/customer-managed-deployment-agent:latest-arm64"
+      - "{{ .Env.REPO_OWNER }}/customer-managed-deployment-agent:{{ .Tag }}-arm64"
+      - "{{ .Env.REPO_OWNER }}/customer-managed-deployment-agent:latest-arm64"
     use: buildx
     goarch: arm64
     build_flag_templates:
       - "--platform=linux/arm64"
+      - "--label=org.opencontainers.image.created={{.Date}}"
+      - "--label=org.opencontainers.image.title={{.ProjectName}}"
+      - "--label=org.opencontainers.image.revision={{.FullCommit}}"
+      - "--label=org.opencontainers.image.version={{.Version}}"
+
+docker_manifests:
+  - name_template: "{{ .Env.REPO_OWNER }}/customer-managed-deployment-agent:{{ .Tag }}"
+    image_templates:
+      - "{{ .Env.REPO_OWNER }}/customer-managed-deployment-agent:{{ .Tag }}-amd64"
+      - "{{ .Env.REPO_OWNER }}/customer-managed-deployment-agent:{{ .Tag }}-arm64"
+  - name_template: "{{ .Env.REPO_OWNER }}/customer-managed-deployment-agent:latest"
+    image_templates:
+      - "{{ .Env.REPO_OWNER }}/customer-managed-deployment-agent:latest-amd64"
+      - "{{ .Env.REPO_OWNER }}/customer-managed-deployment-agent:latest-arm64"
 
 signs:
   - cmd: cosign

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ First run a `docker login` to have valid credentials to your Docker Hub account.
 $ export REPO_OWNER=<your-docker-hub-name>
 $ export BUILD_STAMP=$(cd ./pulumi-service && date -u '+%Y-%m-%d_%I:%M:%S%p')
 $ export BUILD_GIT_HASH=$(cd ./pulumi-service && git rev-parse HEAD)
-$ goreleaser release --skip=validate,sign,archive --clean
+$ goreleaser release --skip=validate,sign,archive,publish --clean
 ```
 
 This should build a multi-arch image for `amd64` and `arm64` architectures and publish it to your own Docker Hub account.

--- a/README.md
+++ b/README.md
@@ -41,3 +41,21 @@ customer-managed-deployment-agent_1.0.0_darwin_arm64.tar.gz: OK
 customer-managed-deployment-agent_1.0.0_linux_amd64.tar.gz: OK
 customer-managed-deployment-agent_1.0.0_linux_arm64.tar.gz: OK
 ```
+
+## Local testing
+
+The setup can be tested locally by overriding the `REPO_OWNER` environment variable. In the official Github Actions
+workflows, this environment variable is set to `pulumi` as the Docker Hub owner of the images. By setting this
+to your own Docker Hub account name, you can test images of work in progress, which should be committed locally as
+GoReleaser will not publish images from a Git repository with changed files.
+
+First run a `docker login` to have valid credentials to your Docker Hub account.
+
+```sh
+$ export REPO_OWNER=<your-docker-hub-name>
+$ export BUILD_STAMP=$(cd ./pulumi-service && date -u '+%Y-%m-%d_%I:%M:%S%p')
+$ export BUILD_GIT_HASH=$(cd ./pulumi-service && git rev-parse HEAD)
+$ goreleaser release --skip=validate,sign,archive --clean
+```
+
+This should build a multi-arch image for `amd64` and `arm64` architectures and publish it to your own Docker Hub account.


### PR DESCRIPTION
Changes:

* Use the environment variable `REPO_OWNER` to allow for building & publishing work in progress to ones own Docker Hub account. Default value defined in official builds is `pulumi`.
* Removed GoReleaser deprecations:
  *  `builds` -> `ids`
  * `format` -> `formats` (with list value)
* Added some standardized [Open Container Initiative](https://opencontainers.org/) labels
* Added documentation to `README.md`