### PR TITLE
feat(kubernetes): expose agent health endpoint for monitoring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 CHANGELOG
 =========
 
+## Unreleased
+
+* Expose `/healthz` endpoint to Prometheus and add documentation in `kubernetes/README.md`
+
 2.0.1 (2026-01-23)
 
 * Fix `debug workflow-runner` command on Kubernetes

--- a/kubernetes/index.ts
+++ b/kubernetes/index.ts
@@ -24,7 +24,12 @@ const agent = new PulumiSelfHostedAgentComponent(
         selfHostedServiceURL: pulumiConfig.get("selfHostedServiceURL") ?? "https://api.pulumi.com",
         imagePullPolicy: pulumiConfig.get("agentImagePullPolicy") || "Always",
         agentReplicas: pulumiConfig.getNumber("agentReplicas") || 3,
-        workerServiceAccount
+        workerServiceAccount,
+        enableServiceMonitor: pulumiConfig.getBoolean("enableServiceMonitor") || false,
     },
     { dependsOn: [ns] },
 );
+
+// Export key resources for reference
+export const agentService = agent.agentService;
+export const serviceMonitor = agent.serviceMonitor;


### PR DESCRIPTION
  - Add container port 8080 to agent deployment spec
  - Create Kubernetes Service to expose health endpoint
  - Add Prometheus annotations for automatic discovery (/healthz path)
  - Add optional ServiceMonitor for Prometheus Operator integration
  - Export service resources in index.ts for external reference

  Enables monitoring tools to scrape the existing /healthz endpoint
  implemented in pulumi-service PR #29617 for agent health metrics.

  Closes #55