### PR TITLE
Do not cache pulumictl in github actions

### DIFF
--- a/.github/workflows/publish-release.yaml
+++ b/.github/workflows/publish-release.yaml
@@ -47,6 +47,5 @@ jobs:
         with:
           repo: pulumi/pulumictl
           tag: v0.0.45
-          cache: enable
       - name: Repository Dispatch
         run: ${{ matrix.job.run-command }}


### PR DESCRIPTION
The caching option of `jaxxstorm/action-install-gh-release` seems to use break the workflow because the GitHub cache service is returning a 503: `getCacheEntry failed: Cache service responded with 503`.

We run this workflow only occasionally, caching is not necessarily needed.

Fixes https://github.com/pulumi/customer-managed-deployment-agent/issues/61