### PR TITLE
Fix invalid syntax in publish-release GHA

### DIFF
--- a/.github/workflows/publish-release.yaml
+++ b/.github/workflows/publish-release.yaml
@@ -23,7 +23,7 @@ jobs:
 
   dispatch:
     name: ${{ matrix.job.name }}
-    if: "!contains(${{ github.ref_name }}, '-')"
+    if: ${{ !contains(github.ref_name, '-') }}
     runs-on: ubuntu-latest
     needs: [publish]
     strategy:


### PR DESCRIPTION
Use the correct syntax for checking if the branch name does not contain a hyphen.

Fix warning:
```
 Workflow syntax warning: .github/workflows/publish-release.yaml#L26
.github/workflows/publish-release.yaml (Line: 26, Col: 9): Conditional expression contains literal text outside replacement tokens. This will cause the expression to always evaluate to truthy. Did you mean to put the entire expression inside ${{ }}?
```