### PR TITLE
Fix bugs and improve AI contribution readiness

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,14 @@
+## Summary
+
+<!-- What does this PR change and why? -->
+
+## Changes
+
+-
+
+## Checklist
+
+- [ ] TypeScript components compile (`npx tsc --noEmit` in affected directories)
+- [ ] `CHANGELOG.md` updated (if this is a user-facing change)
+- [ ] No files inside `pulumi-service/` were modified
+- [ ] No secrets or build artifacts included

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,7 +19,8 @@ Release packaging and deployment tooling for Pulumi's customer-managed workflow 
 - `.goreleaser.yaml` -- Release config (builds, Docker images, manifests, signing)
 - `.goreleaser.prerelease.yaml` -- Prerelease config (no `latest` tags, no GitHub release)
 - `docker/` -- Alternative Dockerfile that installs from published releases (not used by GoReleaser)
-- `goreleaser/` -- GoReleaser output directory (gitignored in practice, but present locally after builds)
+- `goreleaser/` -- GoReleaser output directory (gitignored, present locally after builds)
+- `workflow-runner-embeddable` -- Binary artifact copied by GoReleaser post-hook (gitignored, present locally after builds)
 
 ## Development
 
@@ -28,6 +29,23 @@ Release packaging and deployment tooling for Pulumi's customer-managed workflow 
 ```bash
 # Initialize the pulumi-service submodule (required before any build)
 make submodules
+```
+
+### Validating TypeScript Components
+
+There are no automated tests in this repository. Before pushing changes to TypeScript components, verify they compile:
+
+```bash
+# Kubernetes native component
+cd kubernetes && yarn install && npx tsc --noEmit && cd ..
+
+# Kubernetes DinD component (legacy)
+cd kubernetes-dind && yarn install && npx tsc --noEmit && cd ..
+```
+
+The `agent-images/agent-setup/` program uses npm instead of yarn:
+```bash
+cd agent-images/agent-setup && npm install && npx tsc --noEmit && cd ..
 ```
 
 ### Local Testing with GoReleaser
@@ -87,8 +105,9 @@ The agent reads `pulumi-workflow-agent.yaml` at runtime. See `pulumi-workflow-ag
 ## Forbidden Patterns
 
 - **Never edit files inside `pulumi-service/`** -- it is a submodule. Changes go in the `pulumi/pulumi-service` repository.
-- **Never commit the `goreleaser/` directory** -- it contains build artifacts and is gitignored.
+- **Never commit the `goreleaser/` directory or `workflow-runner-embeddable` binary** -- they are build artifacts and are gitignored.
 - **Never commit secrets** (tokens, cosign private keys) -- the `cosign.key` in the repo is encrypted and requires `COSIGN_PASSWORD`.
+- **Never mix package managers** -- use yarn in `kubernetes/` and `kubernetes-dind/`, npm in `agent-images/agent-setup/`.
 
 ## Changelog
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-* None
+* Fix `vpcId` config key typo in `agent-images/agent-setup/` that prevented the optional VPC override from working
 
 ## Released
 

--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -1,3 +1,5 @@
 ### Improvements
 
 ### Bug Fixes
+
+* Fix `vpcId` config key typo in `agent-images/agent-setup/` that prevented the optional VPC override from working

--- a/agent-images/README.md
+++ b/agent-images/README.md
@@ -50,7 +50,7 @@ You can either update the default values in the Packer template or see [the Pack
 ### Steps
 
 1. Clone this repo: `git clone https://github.com/pulumi/customer-managed-workflow-agent.git`
-1. Change to the correct sub-folder folder: `cd customer-managed-workflow-agent/packer`
+1. Change to the correct sub-folder: `cd customer-managed-workflow-agent/agent-images/packer`
 1. Run `packer init .` to initialize the setup
 1. Run `packer validate .` to ensure that the template is correct
 1. Run `packer build .` to build the AMI

--- a/agent-images/agent-setup/index.ts
+++ b/agent-images/agent-setup/index.ts
@@ -5,7 +5,7 @@ export = async () => {
 
   const config = new pulumi.Config();
   const accessToken = config.requireSecret("runnerAccessToken");
-  const vpcId = config.get("vpdId");
+  const vpcId = config.get("vpcId");
   const amiPrefix = config.get("amiPrefix") || "pulumi-workflow-agent";
   const instanceType = config.get("instanceType") || "t3.small";
 


### PR DESCRIPTION
## Summary
- Fix `vpdId` → `vpcId` typo in `agent-images/agent-setup/index.ts` — the optional VPC config override was silently broken because the config key never matched the documented `vpcId`
- Fix incorrect packer path in `agent-images/README.md` — said `cd customer-managed-workflow-agent/packer` but should be `cd customer-managed-workflow-agent/agent-images/packer`
- Expand `AGENTS.md` with TypeScript validation commands, document the gitignored `workflow-runner-embeddable` binary, and add package manager consistency rule (yarn vs npm)
- Add `.github/PULL_REQUEST_TEMPLATE.md` with basic checklist

All issues found by running the `ai-contribution-readiness-audit` skill against this repo.

## Test plan
- [x] Verified `vpcId` matches README documentation and Pulumi config usage
- [x] Verified `agent-images/packer/` path exists
- [x] AGENTS.md stays under 300 lines (now ~118 lines)

🤖 Generated with [Claude Code](https://claude.com/claude-code)